### PR TITLE
Handle Loose References to Zod Objects

### DIFF
--- a/src/rules/require-openapi/rule.test.ts
+++ b/src/rules/require-openapi/rule.test.ts
@@ -21,6 +21,7 @@ ruleTester.run(ruleName, rule, {
     test('object-shape'),
     test('literal-no-openapi'),
     test('optional-no-openapi'),
+    test('reference'),
   ],
   invalid: [
     {

--- a/src/rules/require-openapi/rule.ts
+++ b/src/rules/require-openapi/rule.ts
@@ -36,6 +36,10 @@ export const rule = createRule({
         }
       },
       Property(node) {
+        if (node.value.type === 'Identifier') {
+          return;
+        }
+
         const type = getType(node, context);
 
         if (!type?.isZodType || type.name === 'ZodLiteral') {
@@ -44,7 +48,7 @@ export const rule = createRule({
 
         const openApiCallExpression = findOpenApiCallExpression(node);
 
-        if (!openApiCallExpression && !getInferredComment(node, context)) {
+        if (!openApiCallExpression) {
           return context.report({
             messageId: 'open-api-required',
             node: node.key,

--- a/src/rules/require-openapi/tests/reference.ts
+++ b/src/rules/require-openapi/tests/reference.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+import { ZodOpenApiOperationObject, extendZodWithOpenApi } from 'zod-openapi';
+extendZodWithOpenApi(z);
+
+const QuerySchema = z
+  .object({
+    a: z.string().openapi({ description: 'a', example: 'a' }),
+  })
+  .openapi({ description: 'Query schema' });
+
+const GetJobResponseSchema = z
+  .object({
+    a: z.string().openapi({ description: 'a', example: 'a' }),
+  })
+  .openapi({ description: 'Response schema' });
+
+export const getJobOperation: ZodOpenApiOperationObject = {
+  operationId: 'getJob',
+  summary: 'Get Job',
+  requestParams: {
+    query: QuerySchema,
+  },
+  responses: {
+    '200': {
+      description: 'Successful operation',
+      content: {
+        'application/json': {
+          schema: GetJobResponseSchema,
+        },
+      },
+    },
+  },
+};


### PR DESCRIPTION
At the moment this lint rule gets angry about the lack of `.openapi()` on references. This change removes that requirement